### PR TITLE
[Feat] AWS Environment Support

### DIFF
--- a/example/simple.ts
+++ b/example/simple.ts
@@ -1,0 +1,25 @@
+import * as g from "gconfig";
+import * as d from "debug";
+
+const log = d("gconfig:example");
+log("foo");
+
+const config = new g.Config({
+  awsPrefix: "GCONFIG_",
+  secretsmanagerPrefix: "centaur",
+  notFoundFn: (key: string) => {
+    const log = d("gconfig:example:not_found");
+    log(`Key ${key} not found`);
+  },
+});
+
+async function main() {
+  const someConfig = await config.string({
+    env: "FOO",
+    secretsmanager: "FOO",
+    required: true,
+  });
+  log("user = %s", someConfig);
+}
+
+main().then(() => console.log("Done"));

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".", // This must be specified if "paths" is.
+    "paths": {
+      "gconfig": ["../src"]
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.398.0",
-        "@aws-sdk/client-sts": "^3.398.0"
+        "@aws-sdk/client-sts": "^3.398.0",
+        "debug": "^4.3.4"
       },
       "devDependencies": {
+        "@types/debug": "^4.1.10",
         "@types/node": "^20.5.7",
         "typescript": "^5.2.2"
       }
@@ -1046,6 +1048,21 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.10.tgz",
+      "integrity": "sha512-tOSCru6s732pofZ+sMv9o4o3Zc+Sa8l3bxd/tweTQudFn06vAzb13ZX46Zi6m6EJ+RUbRTHvgQJ1gBtSgkaUYA==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.33",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.33.tgz",
+      "integrity": "sha512-AuHIyzR5Hea7ij0P9q7vx7xu4z0C28ucwjAZC0ja7JhINyCnOw8/DnvAPQQ9TfOlCtZAmCERKQX9+o1mgQhuOQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.5.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.7.tgz",
@@ -1056,6 +1073,22 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
@@ -1077,6 +1110,11 @@
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/strnum": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gconfig",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gconfig",
-      "version": "0.1.3",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-secrets-manager": "^3.398.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gconfig",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
   "homepage": "https://github.com/gordiansoftware/gconfig-ts#readme",
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.398.0",
-    "@aws-sdk/client-sts": "^3.398.0"
+    "@aws-sdk/client-sts": "^3.398.0",
+    "debug": "^4.3.4"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.10",
     "@types/node": "^20.5.7",
     "typescript": "^5.2.2"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gconfig",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gconfig",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -13,7 +13,7 @@ export class GCacheEntry {
 }
 
 export class GCache {
-  cache: {[key: string]: GCacheEntry};
+  cache: { [key: string]: GCacheEntry };
 
   constructor() {
     this.cache = {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,7 +57,6 @@ export class Config {
     this.cacheEnv = new GCache();
     this.cacheSecretsmanager = new GCache();
     this.cfg = this.getEnvConfig();
-    log("%O", this);
   }
 
   getEnvConfig(): EnvConfig {
@@ -79,7 +78,6 @@ export class Config {
       }
     }
 
-    log("config: %O", config);
     return config;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ import {
   RequiredSecretNotFoundException,
 } from "./exceptions";
 import { parseEntry } from "./parse";
+import { isRunningOnAWS } from "./utils/aws";
 
 const log = debug("gconfig:config");
 
@@ -75,6 +76,7 @@ export class Config {
         config[key] = v;
       }
     }
+
     log("config: %O", config);
     return config;
   }
@@ -83,6 +85,11 @@ export class Config {
     log("getting secretsmanager client");
     const cfg = this.getEnvConfig();
     if (this.secretsmanagerClient == null) {
+      if (isRunningOnAWS()) {
+        this.secretsmanagerClient = new SecretsManager();
+        return this.secretsmanagerClient;
+      }
+
       if (cfg.awsAccessKeyId == null) {
         throw new AWSMissingAccessKeyIdException();
       }

--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -1,0 +1,31 @@
+/**
+ * Checks if the current execution environment is AWS.
+ *
+ * This function looks for environment variables that are
+ * set by AWS services. For example, AWS Lambda sets various
+ * environment variables such as `AWS_LAMBDA_FUNCTION_NAME`,
+ * and EC2 instances have `AWS_EC2_METADATA_DISABLED`.
+ *
+ * @returns {boolean} `true` if the code is running on AWS, otherwise `false`.
+ */
+export function isRunningOnAWS(): boolean {
+  // Check for AWS Lambda environment variables
+  if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
+    return true;
+  }
+
+  // Check for an EC2 instance environment variable
+  if (process.env.AWS_EC2_METADATA_DISABLED !== undefined) {
+    return true;
+  }
+
+  // Check for an ECS container environment variables
+  if (process.env.ECS_CONTAINER_METADATA_URI || process.env.ECS_AGENT_URI) {
+    return true;
+  }
+
+  // Add additional AWS service environment checks if necessary
+
+  // If none of the AWS-specific variables are set, we're likely not running on AWS
+  return false;
+}

--- a/src/utils/aws.ts
+++ b/src/utils/aws.ts
@@ -1,3 +1,6 @@
+import debug from "debug";
+const log = debug("gconfig:utils:aws");
+
 /**
  * Checks if the current execution environment is AWS.
  *
@@ -11,21 +14,27 @@
 export function isRunningOnAWS(): boolean {
   // Check for AWS Lambda environment variables
   if (process.env.AWS_LAMBDA_FUNCTION_NAME) {
+    log("Running on AWS because AWS_LAMBDA_FUNCTION_NAME is set");
     return true;
   }
 
   // Check for an EC2 instance environment variable
   if (process.env.AWS_EC2_METADATA_DISABLED !== undefined) {
+    log("Running on AWS because AWS_EC2_METADATA_DISABLED is set");
     return true;
   }
 
   // Check for an ECS container environment variables
   if (process.env.ECS_CONTAINER_METADATA_URI || process.env.ECS_AGENT_URI) {
+    log(
+      "Running on AWS because ECS_CONTAINER_METADATA_URI or ECS_AGENT_URI is set"
+    );
     return true;
   }
 
   // Add additional AWS service environment checks if necessary
 
   // If none of the AWS-specific variables are set, we're likely not running on AWS
+  log("no AWS-specific environment found, assuming not running on AWS");
   return false;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,12 +7,10 @@
     "sourceMap": true,
     "moduleResolution": "NodeNext"
   },
-  "include": [
-    "src/**/*"
-  ],
+  "include": ["src/**/*"],
   "ts-node": {
     "experimentalSpecifierResolution": "node",
     "transpileOnly": true,
-    "esm": true,
+    "esm": true
   }
 }


### PR DESCRIPTION
This PR adds support for running in the AWS environment. `gconfig` will try to determine if it is running in AWS and if so, it will not use credentials to try to assume role. 

Additionally, the following changes are being made:
* Debug logging via the [`debug`](https://www.npmjs.com/package/debug) utility
* Debug logging is controlled via a `DEBUG` env variable, see docs above
* Add an example app to test functionality